### PR TITLE
Add support for simple generic actions

### DIFF
--- a/src/__tests__/__snapshots__/create-action.dts.spec.ts.snap
+++ b/src/__tests__/__snapshots__/create-action.dts.spec.ts.snap
@@ -8,22 +8,32 @@ exports[`createAction createAction(
       resolve => (error: Error, meta?: { status: number }) => resolve(error, meta)
     ) 1`] = `"((error: Error, meta?: { status: number; } | undefined) => { type: \\"[Todo] fetch rejected\\"; payload: Error; meta: { status: number; }; error: true; }) & { type: \\"[Todo] fetch rejected\\"; toString(): \\"[Todo] fetch rejected\\"; }"`;
 
+exports[`createAction createAction(
+      '[Todo] generic',
+      resolve => <Name, Meta>(name: Name, meta: Meta) => resolve(name, meta)
+    ) (type) should match snapshot: createAction createAction(
+      '[Todo] generic',
+      resolve => <Name, Meta>(name: Name, meta: Meta) => resolve(name, meta)
+    ) 1`] = `"(<Name, Meta>(name: Name, meta: Meta) => Action<\\"[Todo] generic\\", Name, Meta>) & { type: \\"[Todo] generic\\"; toString(): \\"[Todo] generic\\"; }"`;
+
 exports[`createAction createAction('[Todo] add', resolve => (name: string, completed = false) =>
       resolve({ name, completed })
     ) (type) should match snapshot: createAction createAction('[Todo] add', resolve => (name: string, completed = false) =>
       resolve({ name, completed })
-    ) 1`] = `"((name: string, completed?: any) => { type: \\"[Todo] add\\"; payload: { name: string; completed: any; }; }) & { type: \\"[Todo] add\\"; toString(): \\"[Todo] add\\"; }"`;
+    ) 1`] = `"(<T>(name: string, completed?: any) => { type: \\"[Todo] add\\"; payload: { name: string; completed: any; }; }) & { type: \\"[Todo] add\\"; toString(): \\"[Todo] add\\"; }"`;
 
 exports[`createAction createAction('[Todo] add', resolve => (name: string, completed = false) =>
       resolve({ name, completed }, 'Meta data of all todos')
     ) (type) should match snapshot: createAction createAction('[Todo] add', resolve => (name: string, completed = false) =>
       resolve({ name, completed }, 'Meta data of all todos')
-    ) 1`] = `"((name: string, completed?: any) => { type: \\"[Todo] add\\"; payload: { name: string; completed: any; }; meta: string; }) & { type: \\"[Todo] add\\"; toString(): \\"[Todo] add\\"; }"`;
+    ) 1`] = `"(<T>(name: string, completed?: any) => { type: \\"[Todo] add\\"; payload: { name: string; completed: any; }; meta: string; }) & { type: \\"[Todo] add\\"; toString(): \\"[Todo] add\\"; }"`;
 
 exports[`createAction createAction('[Todo] fetch rejected', resolve => (error: Error) =>
       resolve(error)
     ) (type) should match snapshot: createAction createAction('[Todo] fetch rejected', resolve => (error: Error) =>
       resolve(error)
     ) 1`] = `"((error: Error) => { type: \\"[Todo] fetch rejected\\"; payload: Error; error: true; }) & { type: \\"[Todo] fetch rejected\\"; toString(): \\"[Todo] fetch rejected\\"; }"`;
+
+exports[`createAction createAction('[Todo] generic', resolve => <Name>(name: Name) => resolve(name)) (type) should match snapshot: createAction createAction('[Todo] generic', resolve => <Name>(name: Name) => resolve(name)) 1`] = `"(<Name>(name: Name) => Action<\\"[Todo] generic\\", Name, undefined>) & { type: \\"[Todo] generic\\"; toString(): \\"[Todo] generic\\"; }"`;
 
 exports[`createAction createAction('[Todo] truncate') (type) should match snapshot: createAction createAction('[Todo] truncate') 1`] = `"(() => { type: \\"[Todo] truncate\\"; }) & { type: \\"[Todo] truncate\\"; toString(): \\"[Todo] truncate\\"; }"`;

--- a/src/__tests__/create-action.dts.spec.ts
+++ b/src/__tests__/create-action.dts.spec.ts
@@ -25,3 +25,12 @@ createAction('[Todo] add', resolve => (name: string, completed = false) =>
 createAction('[Todo] add', resolve => (name: string, completed = false) =>
   resolve({ name, completed }, 'Meta data of all todos')
 )
+
+// @dts-jest:pass:snap
+createAction('[Todo] generic', resolve => <Name>(name: Name) => resolve(name))
+
+// @dts-jest:pass:snap
+createAction(
+  '[Todo] generic',
+  resolve => <Name, Meta>(name: Name, meta: Meta) => resolve(name, meta)
+)

--- a/src/create-action.ts
+++ b/src/create-action.ts
@@ -42,7 +42,7 @@ export type ActionCreator<T extends AnyAction | string> = T extends AnyAction
  */
 export function createAction<
   Type extends string,
-  Callable extends (...args: any[]) => Action<Type> = () => Action<Type>
+  Callable extends <T>(...args: any[]) => Action<Type> = () => Action<Type>
 >(
   type: Type,
   executor: (


### PR DESCRIPTION
Added generic type to Callable type to allow creation of generic actions.

**Motivation:**

I have an action that takes an interface used as a base for many other classes in it's payload. I would like to be able to type check against the derived type I'm currently trying to send into the action and not the base interface. Adding a generic argument to returned callback type allows me to do that easily.

**Example:**

```ts
interface IFoo {
  a: A;
  b: B;
}

class Goo implements IFoo {
  a: A;
  b: B;
  c: C;
}

const action = createAction("ACTION", resolve => <T extends IFoo>(value: T) => resolve(value));

const reducer = createReducer(/*..*/.);

// Call to action is properly checked against expected derived Goo
reducer(undefined, action<Goo>(new Goo())
```