### PR TITLE
Tree-shaking issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "unpkg": "dist/deox.umd.min.js",
+  "sideEffects": false,
   "repository": "https://github.com/thebrodmann/deox",
   "author": "Mohammad Hasani <atretoname@gmail.com> (https://github.com/thebrodmann)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
-  "browser": "dist/deox.umd.min.js",
+  "unpkg": "dist/deox.umd.min.js",
   "repository": "https://github.com/thebrodmann/deox",
   "author": "Mohammad Hasani <atretoname@gmail.com> (https://github.com/thebrodmann)",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ const externals = [
 export default [
   {
     input: './tmp/index.js',
-    output: { name: 'Deox', file: pkg.browser, format: 'umd' },
+    output: { name: 'Deox', file: pkg.unpkg, format: 'umd' },
     plugins: [resolve(), commonjs(), sourcemaps(), terser(), filesize()],
   },
   {


### PR DESCRIPTION
According to #43 and https://github.com/webpack/webpack/issues/4674 the `browser` field in package.json file cause that Webpack follows UMD bundle instead of ESM bundle that has been defined in `module` field.

This PR should fix #43.