### PR TITLE
Adhere to generic naming convention

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -1,16 +1,16 @@
 export type Action<
-  Type extends string,
-  Payload = undefined,
-  Meta = undefined
-> = Payload extends undefined
-  ? (Meta extends undefined ? { type: Type } : { type: Type; meta: Meta })
-  : (Payload extends Error
-      ? (Meta extends undefined
-          ? { type: Type; payload: Payload; error: true }
-          : { type: Type; payload: Payload; meta: Meta; error: true })
-      : (Meta extends undefined
-          ? { type: Type; payload: Payload }
-          : { type: Type; payload: Payload; meta: Meta }))
+  TType extends string,
+  TPayload = undefined,
+  TMeta = undefined
+> = TPayload extends undefined
+  ? (TMeta extends undefined ? { type: TType } : { type: TType; meta: TMeta })
+  : (TPayload extends Error
+      ? (TMeta extends undefined
+          ? { type: TType; payload: TPayload; error: true }
+          : { type: TType; payload: TPayload; meta: TMeta; error: true })
+      : (TMeta extends undefined
+          ? { type: TType; payload: TPayload }
+          : { type: TType; payload: TPayload; meta: TMeta }))
 export type AnyAction = Action<string>
 
 /**
@@ -18,45 +18,45 @@ export type AnyAction = Action<string>
  * @example
  * const clearTodos = action('[Todo] truncate');
  */
-export function action<Type extends string>(type: Type): Action<Type>
+export function action<TType extends string>(type: TType): Action<TType>
 /**
  * Action with error factory
  * @example
  * const fetchTodosRejected = (payload: Error) => action('[Todo] fetch rejected', payload);
  */
-export function action<Type extends string, Payload extends Error>(
-  type: Type,
-  payload: Payload
-): Action<Type, Payload>
+export function action<TType extends string, TPayload extends Error>(
+  type: TType,
+  payload: TPayload
+): Action<TType, TPayload>
 /**
  * Action with non-error payload factory
  * @example
  * const addTodo = ({ name, completed = false }: Todo) => action('[Todo] add', { name, completed });
  */
-export function action<Type extends string, Payload>(
-  type: Type,
-  payload: Payload
-): Action<Type, Payload>
+export function action<TType extends string, TPayload>(
+  type: TType,
+  payload: TPayload
+): Action<TType, TPayload>
 /**
  * Action with error and meta factory
  * @example
  * const fetchTodosRejected = (payload: Error, meta?: Meta) => action('[Todo] fetch rejected', payload, meta);
  */
-export function action<Type extends string, Payload extends Error, Meta>(
-  type: Type,
-  payload: Payload,
-  meta: Meta
-): Action<Type, Payload, Meta>
+export function action<TType extends string, TPayload extends Error, TMeta>(
+  type: TType,
+  payload: TPayload,
+  meta: TMeta
+): Action<TType, TPayload, TMeta>
 /**
  * Action with payload and meta factory
  * @example
  * const addTodo = ({ name, completed = false }: Todo, meta?: Meta) => action('[Todo] add', { name, completed }, meta);
  */
-export function action<Type extends string, Payload, Meta>(
-  type: Type,
-  payload: Payload,
-  meta: Meta
-): Action<Type, Payload, Meta>
+export function action<TType extends string, TPayload, TMeta>(
+  type: TType,
+  payload: TPayload,
+  meta: TMeta
+): Action<TType, TPayload, TMeta>
 
 /**
  * Flux standard action factory
@@ -71,10 +71,10 @@ export function action<Type extends string, Payload, Meta>(
  * @example
  * const addTodo = ({ name, completed = false }: Todo, meta?: Meta) => action('[Todo] add', { name, completed }, meta);
  */
-export function action<Type extends string, Payload, Meta>(
-  type: Type,
-  payload?: Payload,
-  meta?: Meta
+export function action<TType extends string, TPayload, TMeta>(
+  type: TType,
+  payload?: TPayload,
+  meta?: TMeta
 ) {
   return {
     type,

--- a/src/create-action-creator.ts
+++ b/src/create-action-creator.ts
@@ -41,16 +41,16 @@ export type ActionCreator<T extends AnyAction | string> = T extends AnyAction
  *
  */
 export function createActionCreator<
-  Type extends string,
-  Callable extends <T>(...args: any[]) => Action<Type> = () => Action<Type>
+  TType extends string,
+  TCallable extends <T>(...args: any[]) => Action<TType> = () => Action<TType>
 >(
-  type: Type,
+  type: TType,
   executor: (
     resolve: <Payload = undefined, Meta = undefined>(
       payload?: Payload,
       meta?: Meta
-    ) => Action<Type, Payload, Meta>
-  ) => Callable = resolve => (() => resolve()) as any
+    ) => Action<TType, Payload, Meta>
+  ) => TCallable = resolve => (() => resolve()) as any
 ) {
   const callable = executor((payload, meta) => action(type, payload!, meta!))
 

--- a/src/create-handler-map.ts
+++ b/src/create-handler-map.ts
@@ -3,17 +3,23 @@ import { AnyAction } from './action'
 import { getType } from './get-type'
 import { Reducer } from './types'
 
-export type HandlerMap<State, Actions extends AnyAction> = {
-  [key in Actions['type']]: Reducer<State, Actions>
+export type HandlerMap<TState, TAction extends AnyAction> = {
+  [type in TAction['type']]: Reducer<TState, TAction>
 }
 
-export type CreateHandlerMap<State> = <
-  AC extends ActionCreator<string>,
-  Actions extends AnyAction = AC extends (...args: any[]) => infer T ? T : never
+export type InferActionFromHandlerMap<
+  THandlerMap extends HandlerMap<any, any>
+> = THandlerMap extends HandlerMap<any, infer T> ? T : never
+
+export type CreateHandlerMap<TPrevState> = <
+  TActionCreator extends ActionCreator<string>,
+  TAction extends AnyAction = TActionCreator extends (...args: any[]) => infer T
+    ? T
+    : never
 >(
-  actionCreators: AC | AC[],
-  handler: Reducer<State, Actions>
-) => HandlerMap<State, Actions>
+  actionCreators: TActionCreator | TActionCreator[],
+  handler: Reducer<TPrevState, TAction>
+) => HandlerMap<TPrevState, TAction>
 
 /**
  * Handler map factory
@@ -24,16 +30,18 @@ export type CreateHandlerMap<State> = <
  * createHandlerMap([increment, increase], (state: number) => state + 1)
  */
 export const createHandlerMap = <
-  AC extends ActionCreator<string>,
-  State,
-  Actions extends AnyAction = AC extends (...args: any[]) => infer T ? T : never
+  TActionCreator extends ActionCreator<string>,
+  TState,
+  TAction extends AnyAction = TActionCreator extends (...args: any[]) => infer T
+    ? T
+    : never
 >(
-  actionCreators: AC | AC[],
-  reducer: Reducer<State, Actions>
+  actionCreators: TActionCreator | TActionCreator[],
+  reducer: Reducer<TState, TAction>
 ) =>
   (Array.isArray(actionCreators) ? actionCreators : [actionCreators])
     .map(getType)
-    .reduce<HandlerMap<State, Actions>>(
+    .reduce<HandlerMap<TState, TAction>>(
       (acc, type) => {
         acc[type] = reducer
         return acc

--- a/src/create-reducer.ts
+++ b/src/create-reducer.ts
@@ -15,15 +15,18 @@ import { DeepImmutable } from './types'
  *   handle(decrement, state => state - 1),
  * ])
  */
-export function createReducer<State, HM extends HandlerMap<State, any>>(
-  defaultState: State,
-  handlerMapsCreator: (handle: CreateHandlerMap<State>) => HM[]
+export function createReducer<
+  TState,
+  THandlerMap extends HandlerMap<TState, any>
+>(
+  defaultState: TState,
+  handlerMapsCreator: (handle: CreateHandlerMap<TState>) => THandlerMap[]
 ) {
   const handlerMap = merge(...handlerMapsCreator(createHandlerMap))
 
   return (
-    state = <DeepImmutable<State>>defaultState,
-    action: HM extends HandlerMap<State, infer T> ? T : never
+    state = <DeepImmutable<TState>>defaultState,
+    action: THandlerMap extends HandlerMap<any, infer T> ? T : never
   ) => {
     const handler = handlerMap[action.type]
 

--- a/src/get-type.ts
+++ b/src/get-type.ts
@@ -12,18 +12,20 @@
  * }) //=> 'TEST'
  */
 export function getType<
-  AC extends { type?: string; toString(): string } | { type: string },
-  Type extends string = AC extends { type: infer T }
+  TActionCreator extends
+    | { type?: string; toString(): string }
+    | { type: string },
+  TType extends string = TActionCreator extends { type: infer T }
     ? T
-    : AC extends { toString(): infer U }
+    : TActionCreator extends { toString(): infer U }
     ? U
     : never
->(actionCreator: AC) {
+>(actionCreator: TActionCreator) {
   if (!actionCreator.type && !actionCreator.hasOwnProperty('toString')) {
     throw new Error(
       `Action creator that has been passed to getType() does not provide any API to expose action type. You can use createAction() to create an action creator without any unsense errors.`
     )
   }
 
-  return <Type>(actionCreator.type || actionCreator.toString())
+  return <TType>(actionCreator.type || actionCreator.toString())
 }

--- a/src/of-type.ts
+++ b/src/of-type.ts
@@ -20,17 +20,17 @@ import { getType } from './get-type'
  * )
  */
 export function ofType<
-  Source extends AnyAction,
-  Key extends ActionCreator<Source> | Source | Source['type'],
-  Sink extends Source = Key extends (...args: any[]) => infer U
-    ? (U extends Source ? U : never)
-    : (Key extends Source ? Key : never)
->(keys: Key | Key[]) {
+  TSource extends AnyAction,
+  TKey extends ActionCreator<TSource> | TSource | TSource['type'],
+  TSink extends TSource = TKey extends (...args: any[]) => infer U
+    ? (U extends TSource ? U : never)
+    : (TKey extends TSource ? TKey : never)
+>(keys: TKey | TKey[]) {
   const types: string[] = (Array.isArray(keys) ? keys : [keys]).map(key =>
     typeof key === 'string' ? key : getType(key)
   )
 
-  return filter<Source, Sink>(
-    (action): action is Sink => types.includes(action.type)
+  return filter<TSource, TSink>(
+    (action): action is TSink => types.includes(action.type)
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,10 +27,10 @@ export type DeepImmutable<T> = T extends Primitive
   ? DeepImmutableMap<K, V>
   : DeepImmutableObject<T>
 
-export type Reducer<State, Actions> = (
-  prevState: DeepImmutable<State>,
-  action: Actions
-) => DeepImmutable<State> | State
+export type Reducer<TState, TAction> = (
+  prevState: DeepImmutable<TState>,
+  action: TAction
+) => DeepImmutable<TState> | TState
 
 export type ActionType<
   T extends ActionCreator<AnyAction> | Reducer<any, Action<any>>


### PR DESCRIPTION
It is a good practice to using descriptive generic parameter names which prefixed by `T`. Causing less naming conflicts 😅.