### PR TITLE
Fix return type of Immutable and DeepImmutable for ReadonlyArray and ReadonlyMap

### DIFF
--- a/src/__tests__/__snapshots__/types.dts.spec.ts.snap
+++ b/src/__tests__/__snapshots__/types.dts.spec.ts.snap
@@ -1,0 +1,157 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeepImmutable displayType<DeepImmutable<Function>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<Function>>() 1`] = `"Function"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<Function[]>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<Function[]>>() 1`] = `"DeepImmutableArray<Function>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<Map<'boolean', boolean>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<Map<'boolean', boolean>>>() 1`] = `"DeepImmutableMap<\\"boolean\\", boolean>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<Map<'function', Function>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<Map<'function', Function>>>() 1`] = `"DeepImmutableMap<\\"function\\", Function>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<Map<'null', null>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<Map<'null', null>>>() 1`] = `"DeepImmutableMap<\\"null\\", null>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<Map<'number', number>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<Map<'number', number>>>() 1`] = `"DeepImmutableMap<\\"number\\", number>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<Map<'string', string>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<Map<'string', string>>>() 1`] = `"DeepImmutableMap<\\"string\\", string>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<Map<'undefined', undefined>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<Map<'undefined', undefined>>>() 1`] = `"DeepImmutableMap<\\"undefined\\", undefined>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<Map<'user', User>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<Map<'user', User>>>() 1`] = `"DeepImmutableMap<\\"user\\", User>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<Map<'users', Users>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<Map<'users', Users>>>() 1`] = `"DeepImmutableMap<\\"users\\", User[]>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyArray<Function>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyArray<Function>>>() 1`] = `"DeepImmutableArray<Function>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyArray<User>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyArray<User>>>() 1`] = `"DeepImmutableArray<User>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyArray<Users>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyArray<Users>>>() 1`] = `"DeepImmutableArray<User[]>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyArray<boolean>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyArray<boolean>>>() 1`] = `"DeepImmutableArray<boolean>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyArray<null>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyArray<null>>>() 1`] = `"DeepImmutableArray<null>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyArray<number>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyArray<number>>>() 1`] = `"DeepImmutableArray<number>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyArray<string>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyArray<string>>>() 1`] = `"DeepImmutableArray<string>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyArray<undefined>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyArray<undefined>>>() 1`] = `"DeepImmutableArray<undefined>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyMap<'boolean', boolean>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyMap<'boolean', boolean>>>() 1`] = `"DeepImmutableMap<\\"boolean\\", boolean>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyMap<'function', Function>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyMap<'function', Function>>>() 1`] = `"DeepImmutableMap<\\"function\\", Function>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyMap<'null', null>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyMap<'null', null>>>() 1`] = `"DeepImmutableMap<\\"null\\", null>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyMap<'number', number>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyMap<'number', number>>>() 1`] = `"DeepImmutableMap<\\"number\\", number>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyMap<'string', string>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyMap<'string', string>>>() 1`] = `"DeepImmutableMap<\\"string\\", string>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyMap<'undefined', undefined>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyMap<'undefined', undefined>>>() 1`] = `"DeepImmutableMap<\\"undefined\\", undefined>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyMap<'user', User>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyMap<'user', User>>>() 1`] = `"DeepImmutableMap<\\"user\\", User>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<ReadonlyMap<'users', Users>>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<ReadonlyMap<'users', Users>>>() 1`] = `"DeepImmutableMap<\\"users\\", User[]>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<User>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<User>>() 1`] = `"DeepImmutableObject<User>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<User[]>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<User[]>>() 1`] = `"DeepImmutableArray<User>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<Users[]>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<Users[]>>() 1`] = `"DeepImmutableArray<User[]>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<boolean>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<boolean>>() 1`] = `"boolean"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<boolean[]>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<boolean[]>>() 1`] = `"DeepImmutableArray<boolean>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<null>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<null>>() 1`] = `"null"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<null[]>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<null[]>>() 1`] = `"DeepImmutableArray<null>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<number>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<number>>() 1`] = `"number"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<number[]>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<number[]>>() 1`] = `"DeepImmutableArray<number>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<string>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<string>>() 1`] = `"string"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<string[]>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<string[]>>() 1`] = `"DeepImmutableArray<string>"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<undefined>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<undefined>>() 1`] = `"undefined"`;
+
+exports[`DeepImmutable displayType<DeepImmutable<undefined[]>>() (type) should match snapshot: DeepImmutable displayType<DeepImmutable<undefined[]>>() 1`] = `"DeepImmutableArray<undefined>"`;
+
+exports[`Immutable displayType<Immutable<Function>>() (type) should match snapshot: Immutable displayType<Immutable<Function>>() 1`] = `"Function"`;
+
+exports[`Immutable displayType<Immutable<Function[]>>() (type) should match snapshot: Immutable displayType<Immutable<Function[]>>() 1`] = `"ReadonlyArray<Function>"`;
+
+exports[`Immutable displayType<Immutable<Map<'boolean', boolean>>>() (type) should match snapshot: Immutable displayType<Immutable<Map<'boolean', boolean>>>() 1`] = `"ReadonlyMap<\\"boolean\\", boolean>"`;
+
+exports[`Immutable displayType<Immutable<Map<'function', Function>>>() (type) should match snapshot: Immutable displayType<Immutable<Map<'function', Function>>>() 1`] = `"ReadonlyMap<\\"function\\", Function>"`;
+
+exports[`Immutable displayType<Immutable<Map<'null', null>>>() (type) should match snapshot: Immutable displayType<Immutable<Map<'null', null>>>() 1`] = `"ReadonlyMap<\\"null\\", null>"`;
+
+exports[`Immutable displayType<Immutable<Map<'number', number>>>() (type) should match snapshot: Immutable displayType<Immutable<Map<'number', number>>>() 1`] = `"ReadonlyMap<\\"number\\", number>"`;
+
+exports[`Immutable displayType<Immutable<Map<'string', string>>>() (type) should match snapshot: Immutable displayType<Immutable<Map<'string', string>>>() 1`] = `"ReadonlyMap<\\"string\\", string>"`;
+
+exports[`Immutable displayType<Immutable<Map<'undefined', undefined>>>() (type) should match snapshot: Immutable displayType<Immutable<Map<'undefined', undefined>>>() 1`] = `"ReadonlyMap<\\"undefined\\", undefined>"`;
+
+exports[`Immutable displayType<Immutable<Map<'user', User>>>() (type) should match snapshot: Immutable displayType<Immutable<Map<'user', User>>>() 1`] = `"ReadonlyMap<\\"user\\", User>"`;
+
+exports[`Immutable displayType<Immutable<Map<'users', Users>>>() (type) should match snapshot: Immutable displayType<Immutable<Map<'users', Users>>>() 1`] = `"ReadonlyMap<\\"users\\", User[]>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyArray<Function>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyArray<Function>>>() 1`] = `"ReadonlyArray<Function>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyArray<User>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyArray<User>>>() 1`] = `"ReadonlyArray<User>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyArray<Users>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyArray<Users>>>() 1`] = `"ReadonlyArray<User[]>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyArray<boolean>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyArray<boolean>>>() 1`] = `"ReadonlyArray<boolean>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyArray<null>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyArray<null>>>() 1`] = `"ReadonlyArray<null>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyArray<number>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyArray<number>>>() 1`] = `"ReadonlyArray<number>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyArray<string>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyArray<string>>>() 1`] = `"ReadonlyArray<string>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyArray<undefined>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyArray<undefined>>>() 1`] = `"ReadonlyArray<undefined>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyMap<'boolean', boolean>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyMap<'boolean', boolean>>>() 1`] = `"ReadonlyMap<\\"boolean\\", boolean>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyMap<'function', Function>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyMap<'function', Function>>>() 1`] = `"ReadonlyMap<\\"function\\", Function>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyMap<'null', null>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyMap<'null', null>>>() 1`] = `"ReadonlyMap<\\"null\\", null>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyMap<'number', number>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyMap<'number', number>>>() 1`] = `"ReadonlyMap<\\"number\\", number>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyMap<'string', string>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyMap<'string', string>>>() 1`] = `"ReadonlyMap<\\"string\\", string>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyMap<'undefined', undefined>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyMap<'undefined', undefined>>>() 1`] = `"ReadonlyMap<\\"undefined\\", undefined>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyMap<'user', User>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyMap<'user', User>>>() 1`] = `"ReadonlyMap<\\"user\\", User>"`;
+
+exports[`Immutable displayType<Immutable<ReadonlyMap<'users', Users>>>() (type) should match snapshot: Immutable displayType<Immutable<ReadonlyMap<'users', Users>>>() 1`] = `"ReadonlyMap<\\"users\\", User[]>"`;
+
+exports[`Immutable displayType<Immutable<User>>() (type) should match snapshot: Immutable displayType<Immutable<User>>() 1`] = `"Readonly<User>"`;
+
+exports[`Immutable displayType<Immutable<User[]>>() (type) should match snapshot: Immutable displayType<Immutable<User[]>>() 1`] = `"ReadonlyArray<User>"`;
+
+exports[`Immutable displayType<Immutable<Users[]>>() (type) should match snapshot: Immutable displayType<Immutable<Users[]>>() 1`] = `"ReadonlyArray<User[]>"`;
+
+exports[`Immutable displayType<Immutable<boolean>>() (type) should match snapshot: Immutable displayType<Immutable<boolean>>() 1`] = `"boolean"`;
+
+exports[`Immutable displayType<Immutable<boolean[]>>() (type) should match snapshot: Immutable displayType<Immutable<boolean[]>>() 1`] = `"ReadonlyArray<boolean>"`;
+
+exports[`Immutable displayType<Immutable<null>>() (type) should match snapshot: Immutable displayType<Immutable<null>>() 1`] = `"null"`;
+
+exports[`Immutable displayType<Immutable<null[]>>() (type) should match snapshot: Immutable displayType<Immutable<null[]>>() 1`] = `"ReadonlyArray<null>"`;
+
+exports[`Immutable displayType<Immutable<number>>() (type) should match snapshot: Immutable displayType<Immutable<number>>() 1`] = `"number"`;
+
+exports[`Immutable displayType<Immutable<number[]>>() (type) should match snapshot: Immutable displayType<Immutable<number[]>>() 1`] = `"ReadonlyArray<number>"`;
+
+exports[`Immutable displayType<Immutable<string>>() (type) should match snapshot: Immutable displayType<Immutable<string>>() 1`] = `"string"`;
+
+exports[`Immutable displayType<Immutable<string[]>>() (type) should match snapshot: Immutable displayType<Immutable<string[]>>() 1`] = `"ReadonlyArray<string>"`;
+
+exports[`Immutable displayType<Immutable<undefined>>() (type) should match snapshot: Immutable displayType<Immutable<undefined>>() 1`] = `"undefined"`;
+
+exports[`Immutable displayType<Immutable<undefined[]>>() (type) should match snapshot: Immutable displayType<Immutable<undefined[]>>() 1`] = `"ReadonlyArray<undefined>"`;

--- a/src/__tests__/types.dts.spec.ts
+++ b/src/__tests__/types.dts.spec.ts
@@ -1,0 +1,180 @@
+import { DeepImmutable, Immutable } from '../types'
+
+function displayType<T>(): T {
+  return <any>undefined
+}
+
+type User = { name: string; age: number; children: Users; parents: Users }
+type Users = User[]
+
+// @dts-jest:group Immutable
+
+// @dts-jest:pass:snap
+displayType<Immutable<undefined>>()
+// @dts-jest:pass:snap
+displayType<Immutable<null>>()
+// @dts-jest:pass:snap
+displayType<Immutable<boolean>>()
+// @dts-jest:pass:snap
+displayType<Immutable<string>>()
+// @dts-jest:pass:snap
+displayType<Immutable<number>>()
+// @dts-jest:pass:snap
+displayType<Immutable<Function>>()
+
+// @dts-jest:pass:snap
+displayType<Immutable<User>>()
+
+// @dts-jest:pass:snap
+displayType<Immutable<undefined[]>>()
+// @dts-jest:pass:snap
+displayType<Immutable<null[]>>()
+// @dts-jest:pass:snap
+displayType<Immutable<boolean[]>>()
+// @dts-jest:pass:snap
+displayType<Immutable<string[]>>()
+// @dts-jest:pass:snap
+displayType<Immutable<number[]>>()
+// @dts-jest:pass:snap
+displayType<Immutable<Function[]>>()
+// @dts-jest:pass:snap
+displayType<Immutable<User[]>>()
+// @dts-jest:pass:snap
+displayType<Immutable<Users[]>>()
+
+// @dts-jest:pass:snap
+displayType<Immutable<Map<'undefined', undefined>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<Map<'null', null>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<Map<'boolean', boolean>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<Map<'string', string>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<Map<'number', number>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<Map<'function', Function>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<Map<'user', User>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<Map<'users', Users>>>()
+
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyArray<undefined>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyArray<null>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyArray<boolean>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyArray<string>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyArray<number>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyArray<Function>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyArray<User>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyArray<Users>>>()
+
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyMap<'undefined', undefined>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyMap<'null', null>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyMap<'boolean', boolean>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyMap<'string', string>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyMap<'number', number>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyMap<'function', Function>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyMap<'user', User>>>()
+// @dts-jest:pass:snap
+displayType<Immutable<ReadonlyMap<'users', Users>>>()
+
+// @dts-jest:group DeepImmutable
+
+// @dts-jest:pass:snap
+displayType<DeepImmutable<undefined>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<null>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<boolean>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<string>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<number>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<Function>>()
+
+// @dts-jest:pass:snap
+displayType<DeepImmutable<User>>()
+
+// @dts-jest:pass:snap
+displayType<DeepImmutable<undefined[]>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<null[]>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<boolean[]>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<string[]>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<number[]>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<Function[]>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<User[]>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<Users[]>>()
+
+// @dts-jest:pass:snap
+displayType<DeepImmutable<Map<'undefined', undefined>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<Map<'null', null>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<Map<'boolean', boolean>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<Map<'string', string>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<Map<'number', number>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<Map<'function', Function>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<Map<'user', User>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<Map<'users', Users>>>()
+
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyArray<undefined>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyArray<null>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyArray<boolean>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyArray<string>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyArray<number>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyArray<Function>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyArray<User>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyArray<Users>>>()
+
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyMap<'undefined', undefined>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyMap<'null', null>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyMap<'boolean', boolean>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyMap<'string', string>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyMap<'number', number>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyMap<'function', Function>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyMap<'user', User>>>()
+// @dts-jest:pass:snap
+displayType<DeepImmutable<ReadonlyMap<'users', Users>>>()

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,10 @@ export type Immutable<T> = T extends Primitive
   ? ReadonlyArray<U>
   : T extends Map<infer K, infer V>
   ? ReadonlyMap<K, V>
+  : T extends ReadonlyArray<any>
+  ? T
+  : T extends ReadonlyMap<any, any>
+  ? T
   : Readonly<T>
 
 export type DeepImmutable<T> = T extends Primitive
@@ -24,6 +28,10 @@ export type DeepImmutable<T> = T extends Primitive
   : T extends Array<infer U>
   ? DeepImmutableArray<U>
   : T extends Map<infer K, infer V>
+  ? DeepImmutableMap<K, V>
+  : T extends ReadonlyArray<infer U>
+  ? DeepImmutableArray<U>
+  : T extends ReadonlyMap<infer K, infer V>
   ? DeepImmutableMap<K, V>
   : DeepImmutableObject<T>
 


### PR DESCRIPTION
This PR closes #65.
Also, it adds some tests for `Immutable` and `DeepImmutable` types.