### PR TITLE
Make using DeepImmutable optional in input/prev state

### DIFF
--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -227,3 +227,23 @@ A type that creates Flux-standard compliant action.
 ## _ActionType<T\>_
 
 A type that infers action from (**_ActionCreator_** ) or (**_Reducer_** ).
+
+## _DeepImmutable<T\>_
+
+A type which gives any type as input and return corresponding **deeply** immutable data structure as output.
+
+## _DeepImmutableObject<T\>_
+
+A type which gives an `object` type as input and return corresponding **deeply** immutable data structure as output.
+
+## _DeepImmutableMap<T\>_
+
+A type which gives a `Map` type as input and return corresponding **deeply** immutable data structure as output.
+
+## _DeepImmutableArray<T\>_
+
+A type which gives an `Array` type as input and return corresponding \*\*deeply immutable data structure as output.
+
+## _Immutable<T\>_
+
+A type which gives any type as input and return corresponding **shallowly** immutable data structure as output.

--- a/src/__tests__/__snapshots__/create-reducer.dts.spec.ts.snap
+++ b/src/__tests__/__snapshots__/create-reducer.dts.spec.ts.snap
@@ -2,6 +2,6 @@
 
 exports[`createReducer counter scenario (type) should match snapshot: createReducer counter scenario 1`] = `"(state: number | undefined, action: { type: \\"INCREMENT\\"; } | { type: \\"DECREMENT\\"; } | { type: \\"RESET\\"; payload: number; }) => number"`;
 
-exports[`createReducer immutable items list scenario (type) should match snapshot: createReducer immutable items list scenario 1`] = `"(state: DeepImmutableArray<DeepImmutableObject<Item>> | undefined, action: { type: \\"IDENTITY\\"; } | { type: \\"ADD_ITEM\\"; payload: string; } | { type: \\"REMOVE_ITEM\\"; payload: string; }) => DeepImmutableArray<DeepImmutableObject<Item>> | DeepImmutableObject<DeepImmutableObject<Item>>[]"`;
+exports[`createReducer immutable items list scenario (type) should match snapshot: createReducer immutable items list scenario 1`] = `"(state: DeepImmutableArray<Item> | undefined, action: { type: \\"IDENTITY\\"; } | { type: \\"ADD_ITEM\\"; payload: string; } | { type: \\"REMOVE_ITEM\\"; payload: string; }) => DeepImmutableArray<Item> | DeepImmutableObject<Item>[]"`;
 
-exports[`createReducer mutable items list scenario (type) should match snapshot: createReducer mutable items list scenario 1`] = `"(state: DeepImmutableArray<Item> | undefined, action: { type: \\"IDENTITY\\"; } | { type: \\"ADD_ITEM\\"; payload: string; } | { type: \\"REMOVE_ITEM\\"; payload: string; }) => DeepImmutableArray<Item> | DeepImmutableObject<Item>[]"`;
+exports[`createReducer mutable items list scenario (type) should match snapshot: createReducer mutable items list scenario 1`] = `"(state: Item[] | undefined, action: { type: \\"IDENTITY\\"; } | { type: \\"ADD_ITEM\\"; payload: string; } | { type: \\"REMOVE_ITEM\\"; payload: string; }) => Item[]"`;

--- a/src/create-reducer.ts
+++ b/src/create-reducer.ts
@@ -6,7 +6,6 @@ import {
   InferNextStateFromHandlerMap,
 } from './create-handler-map'
 import { merge } from './utils'
-import { DeepImmutable } from './types'
 
 /**
  * Reducer factory
@@ -19,17 +18,15 @@ import { DeepImmutable } from './types'
  */
 export function createReducer<
   TPrevState,
-  THandlerMap extends HandlerMap<DeepImmutable<TPrevState>, any, any>
+  THandlerMap extends HandlerMap<TPrevState, any, any>
 >(
   defaultState: TPrevState,
-  handlerMapsCreator: (
-    handle: CreateHandlerMap<DeepImmutable<TPrevState>>
-  ) => THandlerMap[]
+  handlerMapsCreator: (handle: CreateHandlerMap<TPrevState>) => THandlerMap[]
 ) {
   const handlerMap = merge(...handlerMapsCreator(createHandlerMap))
 
   return (
-    state = <DeepImmutable<TPrevState>>defaultState,
+    state = defaultState,
     action: InferActionFromHandlerMap<THandlerMap>
   ): InferNextStateFromHandlerMap<THandlerMap> => {
     const handler = handlerMap[action.type]

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,11 @@ export {
 export { getType } from './get-type'
 export { createReducer } from './create-reducer'
 export { ofType } from './of-type'
-export { ActionType } from './types'
+export {
+  ActionType,
+  Immutable,
+  DeepImmutable,
+  DeepImmutableArray,
+  DeepImmutableMap,
+  DeepImmutableObject,
+} from './types'


### PR DESCRIPTION
As a conclusion in #58 and #55; This PR make using `DeepImmutable` optional in handler's input/prev state argument.

### Public API Changes

Rationally, because using `DeepImmutable` is optional, public API should export immutability type helpers.

#### Adds

- `Immutable`
- `DeepImmutable`
- `DeepImmutableArray`
- `DeepImmutableMap`
- `DeepImmutableObject`
