### PR TITLE
Upgrade redux-starter-kit to version 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepare": "not-in-install || { npm run test && npm run test-dts && npm run build; }"
   },
   "dependencies": {
-    "redux-starter-kit": "0.4.3",
+    "redux-starter-kit": "0.5.1",
     "rxjs": "^6.3.3",
     "tslib": "^1.9.3"
   },


### PR DESCRIPTION
There are some typing troubles with `redux-starter-kit@<0.5.1` which has been discussed in [this gist](https://gist.github.com/mels065/888abf691ec2b0dba8ce0f57453d50a8) by @mels065.
This PR upgrades the `redux-starter-kit` to version `0.5.1` to solve the explained issue.