### PR TITLE
Implement ActionCreatorFactory and ReducerFactory

### DIFF
--- a/src/create-action-creator-factory.ts
+++ b/src/create-action-creator-factory.ts
@@ -1,56 +1,77 @@
-import { Action } from './create-action'
-import { createActionCreator } from './create-action-creator'
+import { action, Action } from "deox";
 
-type ReplaceActionType<
-  TAction extends Action<string>,
-  TNewType extends string
-> = TAction extends Action<string, infer P, infer M>
-  ? Action<TNewType, P, M>
-  : (TAction extends Action<string, infer P>
-    ? Action<TNewType, P>
-    : (TAction extends Action<string, undefined, infer M>
-      ? Action<TNewType, undefined, M>
-      : Action<TNewType>));
+export type Resolver<TType extends string> = <
+  TPayload = undefined,
+  TMeta = undefined
+  >(
+  payload?: TPayload,
+  meta?: TMeta
+) => Action<TType, TPayload, TMeta>;
 
-type Executor = (
-  resolve: <TPayload = undefined, TMeta = undefined>(
-    payload?: TPayload,
-    meta?: TMeta
-  ) => Action<string, TPayload, TMeta>
-) => (...args: any) => Action<string>;
+type ActionProducer<TType extends string> = (...args: any) => Action<TType>;
 
-type CreatorMap = Record<string, Executor>;
-type ActionTypeMap<T> = Record<keyof T, string>;
+type FactoryActionCreator<
+  TType extends string,
+  TProducer extends ActionProducer<TType>
+  > = TProducer & { type: TType; toString(): TType };
+
+type Executor<TType extends string, TProducer extends ActionProducer<TType>> = (
+  resolve: Resolver<TType>
+) => TProducer;
+
+type ActionCreatorProducer<
+  TType extends string,
+  TProducer extends ActionProducer<TType>
+  > = (type: TType) => FactoryActionCreator<TType, TProducer>;
+
+export type ExecutorHandler = <
+  TType extends string,
+  TProducer extends ActionProducer<TType>
+  >(
+  executor: Executor<TType, TProducer>
+) => ActionCreatorProducer<TType, TProducer>;
+
+type CreatorMap = Record<string, any>;
+
+type ActionProducerMap<T extends CreatorMap> = {
+  [key in keyof T]: (creator: T[key]) => FactoryActionCreator<string, any>;
+};
+
+type ResolverCreator = <TType extends string>(type: TType) => Resolver<TType>;
 
 type ActionCreatorMap<
   TCreators extends CreatorMap,
-  TActionTypes extends ActionTypeMap<TCreators>
-> = {
-  readonly [TKey in keyof TCreators]: {
-    (...args: Parameters<ReturnType<TCreators[TKey]>>): ReplaceActionType<
-      ReturnType<ReturnType<TCreators[TKey]>>,
-      TActionTypes[TKey]
-    >;
-    type: TActionTypes[TKey];
-    toString(): TActionTypes[TKey];
-  };
+  TActionTypes extends ActionProducerMap<TCreators>
+  > = {
+  readonly [TKey in keyof TCreators]: ReturnType<TActionTypes[TKey]>;
 };
 
 type ActionCreatorFactory<TCreators extends CreatorMap> = <
-  TActionTypes extends ActionTypeMap<TCreators>
->(
+  TActionTypes extends ActionProducerMap<TCreators>
+  >(
   types: TActionTypes
 ) => ActionCreatorMap<TCreators, TActionTypes>;
 
 export function createActionCreatorFactory<TCreators extends CreatorMap>(
-  creators: TCreators
+  creators: (handler: ExecutorHandler) => TCreators
 ): ActionCreatorFactory<TCreators> {
-  return <TActionTypes extends Record<keyof TCreators, string>>(
+  return <TActionTypes extends ActionProducerMap<TCreators>>(
     types: TActionTypes
   ) => {
-    return Object.keys(creators).reduce((result, key) => {
+    const resolverCreator: ResolverCreator = (type) => (payload, meta) => {
+      return action(type, payload!, meta!);
+    };
+
+    const factories = creators((executor) => (type) =>
+      Object.assign(executor(resolverCreator(type)), {
+        type,
+        toString: () => type,
+      })
+    );
+    const keys = Object.keys(factories) as (Extract<keyof TCreators, string>)[];
+    return keys.reduce((result, key) => {
       return Object.assign(result, {
-        [key]: createActionCreator(types[key], creators[key]),
+        [key]: types[key](factories[key]),
       });
     }, {}) as ActionCreatorMap<TCreators, TActionTypes>;
   };

--- a/src/create-action-creator-factory.ts
+++ b/src/create-action-creator-factory.ts
@@ -1,0 +1,45 @@
+import { ActionCreator } from './create-action-creator'
+import { Action } from './create-action'
+
+
+type ActionCreatorFactory = (type: string) => ActionCreator<string>;
+
+interface ActionCreatorFactoryMapper {
+  [key: string]: ActionCreatorFactory;
+}
+
+type ActionTypesMap<TMapper extends ActionCreatorFactoryMapper> = {
+  [TKey in keyof TMapper]: string;
+};
+
+type ArgumentTypes<T> = T extends (...args: infer U) => any ? U : never;
+type ReplaceCreatorType<TCreator, TNewType extends string> = TCreator extends (
+  ...a: ArgumentTypes<TCreator>
+  ) => infer A
+  ? A extends Action<string, infer P, infer M>
+    ? (...a: ArgumentTypes<TCreator>) => Action<TNewType, P, M>
+    : (A extends Action<string, infer P>
+      ? (...a: ArgumentTypes<TCreator>) => Action<TNewType, P>
+      : (...a: ArgumentTypes<TCreator>) => A)
+  : never;
+
+type ActionCreatorMap<
+  TMapper extends ActionCreatorFactoryMapper,
+  TNames extends ActionTypesMap<TMapper>
+  > = {
+  [TKey in keyof TMapper]: ReplaceCreatorType<
+    ReturnType<TMapper[TKey]>,
+    TNames[TKey]
+    >;
+};
+
+export function createActionCreatorFactory<TMapper extends ActionCreatorFactoryMapper>(
+  mapper: TMapper
+) {
+  return <TActionTypes extends ActionTypesMap<TMapper>>(names: TActionTypes) =>
+    Object.keys(mapper).reduce<
+      Partial<ActionCreatorMap<TMapper, TActionTypes>>
+      >((result, key) => {
+      return Object.assign(result, { [key]: mapper[key](names[key]) });
+    }, {}) as ActionCreatorMap<TMapper, TActionTypes>;
+}

--- a/src/create-action-creator-factory.ts
+++ b/src/create-action-creator-factory.ts
@@ -68,7 +68,7 @@ export function createActionCreatorFactory<TCreators extends CreatorMap>(
         toString: () => type,
       })
     );
-    const keys = Object.keys(factories) as (Extract<keyof TCreators, string>)[];
+    const keys = Object.keys(factories) as Array<Extract<keyof TCreators, string>>;
     return keys.reduce((result, key) => {
       return Object.assign(result, {
         [key]: types[key](factories[key]),


### PR DESCRIPTION
The concept is very simple, making everything typesafe is when the headache comes.

I have no experience testing types, but I wrote some code to test the types:

```typescript
const factory = createActionCreatorFactory({
  a: (type) =>
    createActionCreator(type, (resolve) => (index: number) =>
      resolve({ index })
    ),
  b: (type) =>
    createActionCreator(type, (resolve) => (name: string) => resolve({ name })),
});

const result = factory({ a: "A", b: "B" } as const);

const actionA = result.a(2); // produces { type: "A", payload: { index: number } } type
const actionAFail = result.a(); // should fail

const actionB = result.b("Bob"); // produces { type: "B", payload: { name: string } } type
const actionFail = result.b(); // should fail

const actionC = result.c(); // should fail
``` 

I will write the unit tests when I get some free time, for the moment I am opening this PR to show the concept that I was talking about at #106.

