### PR TITLE
Support mixed keys for ofType RxJS operator

### DIFF
--- a/src/__tests__/__snapshots__/of-type.dts.spec.ts.snap
+++ b/src/__tests__/__snapshots__/of-type.dts.spec.ts.snap
@@ -4,8 +4,6 @@ exports[`ofType of(a(), b(), c()).pipe(ofType('a')) (type) should match snapshot
 
 exports[`ofType of(a(), b(), c()).pipe(ofType(['a', 'b'])) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; } | { type: \\"b\\"; }>"`;
 
-exports[`ofType of(a(), b(), c()).pipe(ofType(['a', b(), c])) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; } | { type: \\"b\\"; } | { type: \\"c\\"; }>"`;
-
 exports[`ofType of(a(), b(), c()).pipe(ofType([a(), b()])) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; } | { type: \\"b\\"; }>"`;
 
 exports[`ofType of(a(), b(), c()).pipe(ofType([a, b])) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; } | { type: \\"b\\"; }>"`;
@@ -13,3 +11,5 @@ exports[`ofType of(a(), b(), c()).pipe(ofType([a, b])) (type) should match snaps
 exports[`ofType of(a(), b(), c()).pipe(ofType(a())) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; }>"`;
 
 exports[`ofType of(a(), b(), c()).pipe(ofType(a)) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; }>"`;
+
+exports[`ofType of(a(), b(), c(), d()).pipe(ofType(['a', b(), c])) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; } | { type: \\"b\\"; } | { type: \\"c\\"; }>"`;

--- a/src/__tests__/__snapshots__/of-type.dts.spec.ts.snap
+++ b/src/__tests__/__snapshots__/of-type.dts.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`ofType of(a(), b(), c()).pipe(ofType('a')) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; }>"`;
 
-exports[`ofType of(a(), b(), c()).pipe(ofType(['a', 'b'])) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; } | { type: \\"b\\"; }>"`;
+exports[`ofType of(a(), b(), c()).pipe(ofType(<const>['a', 'b'])) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; } | { type: \\"b\\"; }>"`;
 
 exports[`ofType of(a(), b(), c()).pipe(ofType([a(), b()])) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; } | { type: \\"b\\"; }>"`;
 
@@ -12,4 +12,4 @@ exports[`ofType of(a(), b(), c()).pipe(ofType(a())) (type) should match snapshot
 
 exports[`ofType of(a(), b(), c()).pipe(ofType(a)) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; }>"`;
 
-exports[`ofType of(a(), b(), c(), d()).pipe(ofType(['a', b(), c])) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; } | { type: \\"b\\"; } | { type: \\"c\\"; }>"`;
+exports[`ofType of(a(), b(), c(), d()).pipe(ofType(<const>['a', b(), c])) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; } | { type: \\"b\\"; } | { type: \\"c\\"; }>"`;

--- a/src/__tests__/__snapshots__/of-type.dts.spec.ts.snap
+++ b/src/__tests__/__snapshots__/of-type.dts.spec.ts.snap
@@ -2,7 +2,9 @@
 
 exports[`ofType of(a(), b(), c()).pipe(ofType('a')) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; }>"`;
 
-exports[`ofType of(a(), b(), c()).pipe(ofType(['a', 'b'])) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; } | { type: \\"b\\"; } | { type: \\"c\\"; }>"`;
+exports[`ofType of(a(), b(), c()).pipe(ofType(['a', 'b'])) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; } | { type: \\"b\\"; }>"`;
+
+exports[`ofType of(a(), b(), c()).pipe(ofType(['a', b(), c])) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; } | { type: \\"b\\"; } | { type: \\"c\\"; }>"`;
 
 exports[`ofType of(a(), b(), c()).pipe(ofType([a(), b()])) (type) should match snapshot 1`] = `"Observable<{ type: \\"a\\"; } | { type: \\"b\\"; }>"`;
 

--- a/src/__tests__/of-type.dts.spec.ts
+++ b/src/__tests__/of-type.dts.spec.ts
@@ -26,7 +26,7 @@ of(a(), b(), c()).pipe(ofType([a(), b()]))
 of(a(), b(), c()).pipe(ofType('a'))
 
 // @dts-jest:pass:snap
-of(a(), b(), c()).pipe(ofType(['a', 'b']))
+of(a(), b(), c()).pipe(ofType(<const>['a', 'b']))
 
 // @dts-jest:pass:snap
-of(a(), b(), c(), d()).pipe(ofType(['a', b(), c]))
+of(a(), b(), c(), d()).pipe(ofType(<const>['a', b(), c]))

--- a/src/__tests__/of-type.dts.spec.ts
+++ b/src/__tests__/of-type.dts.spec.ts
@@ -8,6 +8,7 @@ import { ofType } from '../of-type'
 const a = createActionCreator('a')
 const b = createActionCreator('b')
 const c = createActionCreator('c')
+const d = createActionCreator('d')
 
 // @dts-jest:pass:snap
 of(a(), b(), c()).pipe(ofType(a))
@@ -28,4 +29,4 @@ of(a(), b(), c()).pipe(ofType('a'))
 of(a(), b(), c()).pipe(ofType(['a', 'b']))
 
 // @dts-jest:pass:snap
-of(a(), b(), c()).pipe(ofType(['a', b(), c]))
+of(a(), b(), c(), d()).pipe(ofType(['a', b(), c]))

--- a/src/__tests__/of-type.dts.spec.ts
+++ b/src/__tests__/of-type.dts.spec.ts
@@ -26,3 +26,6 @@ of(a(), b(), c()).pipe(ofType('a'))
 
 // @dts-jest:pass:snap
 of(a(), b(), c()).pipe(ofType(['a', 'b']))
+
+// @dts-jest:pass:snap
+of(a(), b(), c()).pipe(ofType(['a', b(), c]))

--- a/src/__tests__/of-type.spec.ts
+++ b/src/__tests__/of-type.spec.ts
@@ -77,4 +77,22 @@ describe('ofType', () => {
       keys: ['c', 'd', 'f'],
     },
   ])('should filter in with action type(s)', test)
+
+  it.each([
+    {
+      action: '  -a--b-^-c--d--e--f--c--h--|',
+      subs: '          ^-------------------!',
+      expected: '      --c-----------c-----|',
+      keys: 'c',
+    },
+    {
+      action: '  -a--b-^-c--d--e--f--c--h--|',
+      subs: '          ^-------------------!',
+      expected: '      --c--d-----f--c-----|',
+      keys: ['c', d(), f],
+    },
+  ])(
+    'should filter in with action type(s) or action(s) or action creator(s)',
+    test
+  )
 })

--- a/src/__tests__/of-type.spec.ts
+++ b/src/__tests__/of-type.spec.ts
@@ -82,17 +82,11 @@ describe('ofType', () => {
     {
       action: '  -a--b-^-c--d--e--f--c--h--|',
       subs: '          ^-------------------!',
-      expected: '      --c-----------c-----|',
-      keys: 'c',
-    },
-    {
-      action: '  -a--b-^-c--d--e--f--c--h--|',
-      subs: '          ^-------------------!',
       expected: '      --c--d-----f--c-----|',
       keys: ['c', d(), f],
     },
   ])(
-    'should filter in with action type(s) or action(s) or action creator(s)',
+    'should filter in with action type(s) and action(s) and action creator(s)',
     test
   )
 })

--- a/src/of-type.ts
+++ b/src/of-type.ts
@@ -23,7 +23,7 @@ import { ExtractAction } from './types'
  */
 export function ofType<
   TSource extends AnyAction,
-  TKey extends string | AnyAction | ActionCreator<AnyAction>,
+  TKey extends TSource['type'] | TSource | ActionCreator<TSource>,
   TSink extends TSource = ExtractAction<TKey, TSource>
 >(keys: TKey | ReadonlyArray<TKey>) {
   const types = castArray<string | AnyAction | ActionCreator<AnyAction>>(

--- a/src/of-type.ts
+++ b/src/of-type.ts
@@ -22,15 +22,15 @@ import { ExtractAction } from './types'
  * )
  */
 export function ofType<
-  TSource extends string | AnyAction | ActionCreator<AnyAction>,
-  TAction extends AnyAction
->(keys: TSource | ReadonlyArray<TSource>) {
+  TSource extends AnyAction,
+  TKey extends string | AnyAction | ActionCreator<AnyAction>,
+  TSink extends TSource = ExtractAction<TKey, TSource>
+>(keys: TKey | ReadonlyArray<TKey>) {
   const types = castArray<string | AnyAction | ActionCreator<AnyAction>>(
     keys
   ).map(key => (typeof key === 'string' ? key : getType(key)))
 
-  return filter<TAction, ExtractAction<TSource, TAction>>(
-    (action): action is ExtractAction<TSource, TAction> =>
-      types.includes(action.type)
+  return filter<TSource, TSink>((action): action is TSink =>
+    types.includes(action.type)
   )
 }

--- a/src/of-type.ts
+++ b/src/of-type.ts
@@ -1,10 +1,10 @@
-import { OperatorFunction } from 'rxjs'
 import { filter } from 'rxjs/operators'
 
 import { ActionCreator } from './create-action-creator'
-import { Action, AnyAction } from './create-action'
+import { AnyAction } from './create-action'
 import { getType } from './get-type'
 import { castArray } from './utils'
+import { ExtractAction } from './types'
 
 /**
  * Filter actions emitted by the source Observable by only emitting those that
@@ -22,27 +22,15 @@ import { castArray } from './utils'
  * )
  */
 export function ofType<
-  TSource extends AnyAction,
-  TActionCreator extends ActionCreator<TSource>,
->(
-  actionCreators: TActionCreator | ReadonlyArray<TActionCreator>
-): OperatorFunction<TSource, ReturnType<TActionCreator>>
-export function ofType<TSource extends AnyAction, TAction extends TSource>(
-  actions: TAction | ReadonlyArray<TAction>
-): OperatorFunction<TSource, TAction>
-export function ofType<
-  TSource extends AnyAction,
-  TType extends TSource['type']
->(
-  types: TType | ReadonlyArray<TType>
-): OperatorFunction<
-  TSource,
-  TSource extends Action<infer T> ? (T extends TType ? TSource : never) : never
->
-export function ofType(keys: ActionCreator<AnyAction> | AnyAction | string) {
-  const types = castArray(keys).map(key =>
-    typeof key === 'string' ? key : getType(key)
-  )
+  TSource extends string | AnyAction | ActionCreator<AnyAction>,
+  TAction extends AnyAction
+>(keys: TSource | ReadonlyArray<TSource>) {
+  const types = castArray<string | AnyAction | ActionCreator<AnyAction>>(
+    keys
+  ).map(key => (typeof key === 'string' ? key : getType(key)))
 
-  return filter<AnyAction>(action => types.includes(action.type))
+  return filter<TAction, ExtractAction<TSource, TAction>>(
+    (action): action is ExtractAction<TSource, TAction> =>
+      types.includes(action.type)
+  )
 }


### PR DESCRIPTION
I changed the `ofType` RxJS operator to use `isOfType` helper function too!
We can pass to `ofType` with array mix of action type, action, and action creator as follows.

```ts
const b = createActionCreator('b');
const c = createActionCreator('c');
action$.pipe(
  ofType('a', b(), c),
    ...
)
```